### PR TITLE
Use pacman to install gopass on Arch

### DIFF
--- a/themes/gopass/layouts/index.html
+++ b/themes/gopass/layouts/index.html
@@ -140,7 +140,7 @@ sudo dpkg -i gopass-{{ .Site.Params.main.currentVersion }}-linux-amd64.deb</code
 				<h3>
 					ArchLinux
 				</h3>
-				<pre><code>pacaur -S gopass</code></pre>
+				<pre><code>sudo pacman -S gopass</code></pre>
 				<h3>
 					Gentoo
 				</h3>


### PR DESCRIPTION
gopass is an official Arch package for almost a year now. People can install it from the official repos.