### PR TITLE
Restrict asciicast width to content width

### DIFF
--- a/themes/gopass/src/scss/main.scss
+++ b/themes/gopass/src/scss/main.scss
@@ -47,5 +47,8 @@
             padding: 6px (2*6px);
             border-radius: 6px;
         }
+        img[alt="asciicast"] {
+            width: 100%;
+        }
     }
 }


### PR DESCRIPTION
Prevents asciicast img element from "overflowing" the content width