### PR TITLE
website: make it easier to find usage instructions

### DIFF
--- a/content/docs.md
+++ b/content/docs.md
@@ -89,6 +89,7 @@ gopass was initially started by Matthias Loibl and Dominik Schulz. The majority 
 
 ## Further Documentation
 
+* [Features and usage](https://github.com/gopasspw/gopass/blob/master/docs/features.md)
 * [Security, Known Limitations, and Caveats](https://github.com/gopasspw/gopass/blob/master/docs/security.md)
 * [Configuration](https://github.com/gopasspw/gopass/blob/master/docs/config.md)
 * [FAQ](https://github.com/gopasspw/gopass/blob/master/docs/faq.md)


### PR DESCRIPTION
As a user browsing the gopass website, I always spend time looking for usage instructions. Then sometimes I remember that the usage instructions are actually in a document called "Features".

This PR makes the "features" document more easily findable (at least for people with my approach at reading documentation).